### PR TITLE
Larger fonts + bar rendering

### DIFF
--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/UIMessages.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/UIMessages.java
@@ -139,6 +139,8 @@ public class UIMessages extends NLS {
   public static String CoveragePreferencesCoverageRuntime_message;
   public static String CoveragePreferencesDecoratorsLink_label;
   public static String CoveragePreferencesAnnotationsLink_label;
+  public static String CoveragePreferencesAppearance_title;
+  public static String CoveragePreferencesBarStyle_label;
 
   public static String ClassesViewerEntry_label;
 

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/UIPreferences.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/UIPreferences.java
@@ -15,6 +15,7 @@ import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import com.mountainminds.eclemma.core.ICorePreferences;
+import com.mountainminds.eclemma.internal.ui.barpainters.JaCoCoBarPainter;
 
 /**
  * Constants and initializer for the preference store.
@@ -49,7 +50,10 @@ public class UIPreferences extends AbstractPreferenceInitializer {
       + ".agent_excludes"; //$NON-NLS-1$ 
 
   public static final String PREF_AGENT_EXCLCLASSLOADER = EclEmmaUIPlugin.ID
-      + ".agent_exclclassloader"; //$NON-NLS-1$ 
+      + ".agent_exclclassloader"; //$NON-NLS-1$
+
+  public static final String PREF_BAR_PAINTER = EclEmmaUIPlugin.ID
+      + ".bar_style"; //$NON-NLS-1$ 
 
   public static final ICorePreferences CORE_PREFERENCES = new ICorePreferences() {
     public boolean getActivateNewSessions() {
@@ -107,6 +111,7 @@ public class UIPreferences extends AbstractPreferenceInitializer {
         ICorePreferences.DEFAULT.getAgentExcludes());
     pref.setDefault(PREF_AGENT_EXCLCLASSLOADER,
         ICorePreferences.DEFAULT.getAgentExclClassloader());
+    pref.setDefault(PREF_BAR_PAINTER, JaCoCoBarPainter.class.getName());
   }
 
   private static IPreferenceStore getPreferenceStore() {

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/BarPainter.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/BarPainter.java
@@ -1,0 +1,81 @@
+package com.mountainminds.eclemma.internal.ui.barpainters;
+
+import static com.mountainminds.eclemma.internal.ui.barpainters.BarPainter.Paint.COVERED;
+import static com.mountainminds.eclemma.internal.ui.barpainters.BarPainter.Paint.MISSED;
+
+import java.text.DecimalFormat;
+
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Event;
+import org.jacoco.core.analysis.ICounter;
+
+import com.mountainminds.eclemma.internal.ui.UIMessages;
+
+/**
+ * Base class for implementing BarPainters
+ */
+public abstract class BarPainter {
+
+  private static final String MAX_PERCENTAGE_STRING = new DecimalFormat(
+      UIMessages.CoverageView_columnCoverageValue).format(1.0);
+
+  private static final int DEFAULT_BORDER_LEFT = 2;
+  private static final int DEFAULT_BORDER_RIGHT = 10;
+
+  protected static enum Paint {
+    COVERED, MISSED
+  }
+
+  public void paint(Event event, int columnWith, ICounter counter, int maxTotal) {
+    if (maxTotal == 0) {
+      return;
+    }
+
+    // The bars on GTK will bleed to the header of the table and at the bottom
+    // when rendering just part of the cell. Resetting the clipping seems to be
+    // a workaround for this issue.
+    Rectangle clipping = event.gc.getClipping();
+    event.gc.setClipping(clipping);
+
+    final int maxWidth = getMaxWidth(event, columnWith);
+    final int missedLength = maxWidth * counter.getMissedCount() / maxTotal;
+    paintBar(event, MISSED, 0, missedLength);
+    final int coveredLength = maxWidth * counter.getCoveredCount() / maxTotal;
+    paintBar(event, COVERED, missedLength, coveredLength);
+  }
+
+  public void dispose() {
+    // Nothing to do
+  }
+
+  public void paint(Event event, int columnWith, ICounter counter) {
+    paint(event, columnWith, counter, counter.getTotalCount());
+  }
+
+  protected abstract void paintBar(Event event, Paint type, int xOffset,
+      int width);
+
+  protected int getBorderLeft() {
+    return DEFAULT_BORDER_LEFT;
+  }
+
+  protected int getBorderRight() {
+    return DEFAULT_BORDER_RIGHT;
+  }
+
+  protected int getMaxWidth(Event event, int columnWith) {
+    final int textWidth = event.gc.textExtent(MAX_PERCENTAGE_STRING).x;
+    final int max = columnWith - getBorderLeft() - getBorderRight()
+        - textWidth;
+    return Math.max(0, max);
+  }
+
+  protected int getFontHeight(Event event) {
+    GC gc = event.gc;
+    return gc.getFontMetrics().getAscent()
+        - gc.getFontMetrics().getDescent()
+        + gc.getFontMetrics().getLeading();
+  }
+
+}

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/BarPainterFactory.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/BarPainterFactory.java
@@ -1,0 +1,36 @@
+package com.mountainminds.eclemma.internal.ui.barpainters;
+
+import com.mountainminds.eclemma.internal.ui.EclEmmaUIPlugin;
+import com.mountainminds.eclemma.internal.ui.UIPreferences;
+
+/**
+ * Factory that creates the painters based on the preference page
+ */
+public class BarPainterFactory {
+
+  private BarPainterFactory() {
+    // Factory
+  }
+
+  /**
+   * Returns a new instance of the configured painter. If for any reason the
+   * configured painter cannot be obtained it will log the exception and return
+   * an instance of the default painter.
+   */
+  public static BarPainter newBarPainter() {
+    String barPainterClassName = EclEmmaUIPlugin.getInstance()
+        .getPreferenceStore()
+        .getString(UIPreferences.PREF_BAR_PAINTER);
+    BarPainter barPainter;
+    try {
+      barPainter = (BarPainter) Class.forName(barPainterClassName)
+          .newInstance();
+    } catch (Exception e) {
+      EclEmmaUIPlugin.log(e);
+      // Use the default painter
+      barPainter = new JaCoCoBarPainter();
+    }
+    return barPainter;
+  }
+
+}

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/EclEmmaBarPainter.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/EclEmmaBarPainter.java
@@ -1,0 +1,77 @@
+package com.mountainminds.eclemma.internal.ui.barpainters;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+
+/**
+ * Paints using EclEmma schema colors without gradients
+ */
+public class EclEmmaBarPainter extends BarPainter {
+
+  final private Color missedColorBright;
+  final private Color missedColorDark;
+  final private Color coveredColorBright;
+  final private Color coveredColorDark;
+
+  public EclEmmaBarPainter() {
+    final Display display = Display.getCurrent();
+    missedColorBright = new Color(display, 186, 0, 0);
+    missedColorDark = new Color(display, 161, 0, 0);
+    coveredColorBright = new Color(display, 20, 210, 0);
+    coveredColorDark = new Color(display, 17, 174, 1);
+  }
+
+  @Override
+  protected void paintBar(Event event, Paint type, int xOffset, int width) {
+    // Calculate positions
+    final int cellHeight = event.getBounds().height;
+    final int fontHeight = getFontHeight(event);
+    final int margin = (int) Math.round((cellHeight - fontHeight) / 2d);
+    final int textBase = cellHeight - margin;
+
+    final int height = (int) (fontHeight * 0.75);
+    final int halfHeight = height / 2;
+    final int yBar = event.getBounds().y + textBase - height - 1;
+    final int xBar = event.x + xOffset + getBorderLeft();
+
+    // Colors
+    Color colorBright = null;
+    Color colorDark = null;
+    if (type.equals(Paint.MISSED)) {
+      colorBright = missedColorBright;
+      colorDark = missedColorDark;
+    } else {
+      colorBright = coveredColorBright;
+      colorDark = coveredColorDark;
+    }
+
+    final GC gc = event.gc;
+    // Fill top
+    gc.setForeground(colorBright);
+    gc.setBackground(colorDark);
+    gc.fillGradientRectangle(xBar, yBar, width, halfHeight + 1, true);
+    // Fill bottom
+    gc.setForeground(colorDark);
+    gc.setBackground(colorBright);
+    gc.fillGradientRectangle(xBar, yBar + halfHeight + 1, width, halfHeight,
+        true);
+    // Border
+    final Color borderColor = Display.getCurrent()
+        .getSystemColor(SWT.COLOR_DARK_GRAY);
+    gc.setForeground(borderColor);
+    gc.drawRectangle(xBar, yBar, width, height);
+  }
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    missedColorBright.dispose();
+    missedColorDark.dispose();
+    coveredColorBright.dispose();
+    coveredColorDark.dispose();
+  }
+
+}

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/EclEmmaCleanBarPainter.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/EclEmmaCleanBarPainter.java
@@ -1,0 +1,52 @@
+package com.mountainminds.eclemma.internal.ui.barpainters;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+
+/**
+ * Paints using EclEmma schema colors without gradients
+ */
+public class EclEmmaCleanBarPainter extends BarPainter {
+
+  final Color missedColor;
+  final Color coveredColor;
+
+  public EclEmmaCleanBarPainter() {
+    Display display = Display.getCurrent();
+    missedColor = new Color(display, 161, 0, 0);
+    coveredColor = new Color(display, 17, 174, 1);
+  }
+
+  @Override
+  protected void paintBar(Event event, Paint type, int xOffset, int width) {
+    // Calculate positions
+    final int cellHeight = event.getBounds().height;
+    final int fontHeight = getFontHeight(event);
+    final int margin = (cellHeight - fontHeight) / 2;
+    final int textBase = cellHeight - margin;
+
+    final int height = (int) (fontHeight * 0.75);
+    final int yBar = event.getBounds().y + textBase - height - 1;
+    final int xBar = event.x + xOffset + getBorderLeft();
+
+    // Fill
+    final Color color = type.equals(Paint.MISSED) ? missedColor : coveredColor;
+    GC gc = event.gc;
+    gc.setBackground(color);
+    gc.fillRectangle(xBar, yBar, width, height);
+
+    // Border
+    gc.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY));
+    gc.drawRectangle(xBar, yBar, width, height);
+  }
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    missedColor.dispose();
+    coveredColor.dispose();
+  }
+}

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/JaCoCoBarPainter.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/barpainters/JaCoCoBarPainter.java
@@ -1,0 +1,25 @@
+package com.mountainminds.eclemma.internal.ui.barpainters;
+
+import org.eclipse.swt.widgets.Event;
+
+import com.mountainminds.eclemma.internal.ui.EclEmmaUIPlugin;
+
+public class JaCoCoBarPainter extends BarPainter {
+
+  @Override
+  protected void paintBar(Event event, Paint type, int xOffset, int width) {
+    // Calculate positions
+    final int cellHeight = event.getBounds().height;
+    final int fontHeight = getFontHeight(event);
+    final int margin = (cellHeight - fontHeight) / 2;
+    final int textBase = cellHeight - margin;
+
+    final int yBar = event.getBounds().y + textBase - fontHeight;
+
+    final String imageKey = type.equals(Paint.MISSED) ?
+        EclEmmaUIPlugin.DGM_REDBAR : EclEmmaUIPlugin.DGM_GREENBAR;
+
+    event.gc.drawImage(EclEmmaUIPlugin.getImage(imageKey), 0, 0, 1, 10,
+        event.x + xOffset + getBorderLeft(), yBar, width, fontHeight);
+  }
+}

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/dialogs/CoveragePreferencePage.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/dialogs/CoveragePreferencePage.java
@@ -14,6 +14,7 @@ package com.mountainminds.eclemma.internal.ui.dialogs;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -33,6 +34,9 @@ import com.mountainminds.eclemma.internal.ui.ContextHelp;
 import com.mountainminds.eclemma.internal.ui.EclEmmaUIPlugin;
 import com.mountainminds.eclemma.internal.ui.UIMessages;
 import com.mountainminds.eclemma.internal.ui.UIPreferences;
+import com.mountainminds.eclemma.internal.ui.barpainters.EclEmmaBarPainter;
+import com.mountainminds.eclemma.internal.ui.barpainters.EclEmmaCleanBarPainter;
+import com.mountainminds.eclemma.internal.ui.barpainters.JaCoCoBarPainter;
 
 /**
  * Implementation of the "Code Coverage" preferences page.
@@ -58,6 +62,7 @@ public class CoveragePreferencePage extends FieldEditorPreferencePage implements
     createSessionManagementGroup(result);
     createDefaultScopeGroup(result);
     createCoverageRuntimeGroup(result);
+    createAppearanceGroup(result);
 
     // Links:
     createLink(result, UIMessages.CoveragePreferencesDecoratorsLink_label,
@@ -132,6 +137,25 @@ public class CoveragePreferencePage extends FieldEditorPreferencePage implements
     Label hint = new Label(group, SWT.WRAP);
     GridDataFactory.fillDefaults().span(2, 1).applyTo(hint);
     hint.setText(UIMessages.CoveragePreferencesCoverageRuntime_message);
+    adjustGroupLayout(group);
+  }
+
+  private void createAppearanceGroup(Composite parent) {
+    FieldEditor editor;
+    final Group group = createGroup(parent,
+        UIMessages.CoveragePreferencesAppearance_title);
+
+    String[][] entryNamesAndValues = {
+        { "JaCoCo Reports", JaCoCoBarPainter.class.getName() }, //$NON-NLS-1$
+        { "EclEmma", EclEmmaBarPainter.class.getName() }, //$NON-NLS-1$
+        { "EclEmma - Clean", EclEmmaCleanBarPainter.class.getName() } }; //$NON-NLS-1$
+
+    editor = new ComboFieldEditor(UIPreferences.PREF_BAR_PAINTER,
+        UIMessages.CoveragePreferencesBarStyle_label,
+        entryNamesAndValues, group);
+
+    addField(editor);
+    editor.fillIntoGrid(group, 2);
     adjustGroupLayout(group);
   }
 

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/dialogs/CoveragePropertyPage.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/dialogs/CoveragePropertyPage.java
@@ -38,8 +38,9 @@ import org.jacoco.core.analysis.ICoverageNode;
 import com.mountainminds.eclemma.core.CoverageTools;
 import com.mountainminds.eclemma.core.ICoverageSession;
 import com.mountainminds.eclemma.internal.ui.ContextHelp;
-import com.mountainminds.eclemma.internal.ui.RedGreenBar;
 import com.mountainminds.eclemma.internal.ui.UIMessages;
+import com.mountainminds.eclemma.internal.ui.barpainters.BarPainter;
+import com.mountainminds.eclemma.internal.ui.barpainters.BarPainterFactory;
 
 /**
  * Property page for coverage details of a Java element.
@@ -52,6 +53,14 @@ public class CoveragePropertyPage extends PropertyPage {
   private static final NumberFormat COUNTER_VALUE = DecimalFormat
       .getIntegerInstance();
 
+  private BarPainter barPainter;
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    barPainter.dispose();
+  }
+
   protected Control createContents(Composite parent) {
     ContextHelp.setHelp(parent, ContextHelp.COVERAGE_PROPERTIES);
     noDefaultAndApplyButton();
@@ -61,6 +70,8 @@ public class CoveragePropertyPage extends PropertyPage {
     layout.marginWidth = 0;
     layout.marginHeight = 0;
     parent.setLayout(layout);
+
+    barPainter = BarPainterFactory.newBarPainter();
 
     Label l1 = new Label(parent, SWT.NONE);
     l1.setText(UIMessages.CoveragePropertyPageSession_label);
@@ -114,8 +125,8 @@ public class CoveragePropertyPage extends PropertyPage {
           @Override
           protected void paint(Event event, Object element) {
             final Line line = (Line) element;
-            RedGreenBar
-                .draw(event, table.getColumn(1).getWidth(), line.counter);
+            barPainter
+                .paint(event, table.getColumn(1).getWidth(), line.counter);
           }
 
           @Override

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/uimessages.properties
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/uimessages.properties
@@ -133,6 +133,8 @@ CoveragePreferencesCoverageRuntime_message=Colon separates multiple entries. * a
                                            Please use these options with care, see documentation.
 CoveragePreferencesDecoratorsLink_label=See <a>Label Decorators</a> for coverage decorators.
 CoveragePreferencesAnnotationsLink_label=See <a>Annotations</a> for editor highlighting style.
+CoveragePreferencesAppearance_title=Appearance
+CoveragePreferencesBarStyle_label=Bar style:
 
 ClassesViewerEntry_label={0} - {1}
 


### PR DESCRIPTION
The latest EclEmma version (2.2.0) renders the bar as shown below on my computer running Linux/GTK.

![GTK-Glitch](https://github.com/downloads/renataogarcia/eclemma/bar-jacoco-gtk-glitch.jpg)

The bars become very large and there is also an small glitch that the bars will bleed into the header.

This also happens on Windows when using larger fonts as shown below:
![Win-Lrg](https://github.com/downloads/renataogarcia/eclemma/bar-jacoco-win-lrg.jpg)

Compared to the default font size on Windows:
![Win-Sml](https://github.com/downloads/renataogarcia/eclemma/bar-jacoco-win-sml.jpg)

This patch renders the bar height proportionally to the font height which gives better results. It should also fix the issue with the table header and footer on GTK.

This is how is it rendered on GTK with the patch:
![GTK-jacoco-patch](https://github.com/downloads/renataogarcia/eclemma/bar-jacoco-patch-gtk.jpg)

Additionally the patch allows the user to choose their preferred look of the bar. I provided two implementations aligned to the EclEmma schema colors. Here is a preview:

![GTK-eclemma-patch](https://github.com/downloads/renataogarcia/eclemma/bar-eclemma-patch-gtk.jpg)
