### PR TITLE
Explicitly require hamcrest core so we don't rely on other bundles re-exporting API

### DIFF
--- a/com.mountainminds.eclemma.core.test/META-INF/MANIFEST.MF
+++ b/com.mountainminds.eclemma.core.test/META-INF/MANIFEST.MF
@@ -5,5 +5,6 @@ Bundle-SymbolicName: com.mountainminds.eclemma.core.test
 Bundle-Version: 2.3.3.qualifier
 Bundle-Vendor: Mountainminds GmbH & Co. KG
 Fragment-Host: com.mountainminds.eclemma.core;bundle-version="[2.3.3,3.0.0)"
-Require-Bundle: org.junit;bundle-version="4.0.0"
+Require-Bundle: org.junit;bundle-version="4.0.0",
+ org.hamcrest.core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5


### PR DESCRIPTION
Background:

As a linux distro integrator it is a hard rule that we must build everything from source, which includes the restrictions on re-using pre-built binary artefacts from Orbit. Because we can't re-use things from Orbit, it means that osgi metadata sometimes differs between the upstream project's builds and Orbit builds of a given third-party dependency. We try to stay as close as possible to the upstream project's build to reduce our patch maintenance burden.

The problem:

The com.mountainminds.eclemma.core.test relies on hamcrest core, it does not import "org.hamcrest.core" in the manifest. This means that when re-building against versions of junit that do not reexport the hamcrest core API, the build will fail. Adding an extra requirement on the "org.hamcrest.core" bundle will prevent such a failure.

This pull request contains a small (two-line) patch that makes the dependency on hamcrest more explicit.
