### PR TITLE
Coverage fails, but suite runs fine!

### DIFF
--- a/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/core/EclEmmaStatus.java
+++ b/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/core/EclEmmaStatus.java
@@ -23,11 +23,11 @@ import com.mountainminds.eclemma.internal.core.EclEmmaCorePlugin;
  */
 public final class EclEmmaStatus {
 
-  public final int code;
+  final int code;
 
-  public final int severity;
+  final int severity;
 
-  public final String message;
+  final String message;
 
   private EclEmmaStatus(int code, int severity, String message) {
     this.code = code;
@@ -69,10 +69,22 @@ public final class EclEmmaStatus {
       5000, IStatus.ERROR, CoreMessages.StatusNO_LOCAL_AGENTJAR_ERROR_message);
 
   /**
+   * Error while loading a coverage session.
+   */
+  public static final EclEmmaStatus SESSION_LOAD_ERROR = new EclEmmaStatus(
+      5001, IStatus.ERROR, CoreMessages.StatusSESSION_LOAD_ERROR_message);
+
+  /**
    * The requested launch type is not known.
    */
   public static final EclEmmaStatus UNKOWN_LAUNCH_TYPE_ERROR = new EclEmmaStatus(
       5002, IStatus.ERROR, CoreMessages.StatusUNKOWN_LAUNCH_TYPE_ERROR_message);
+
+  /**
+   * Error while merging sessions.
+   */
+  public static final EclEmmaStatus MERGE_SESSIONS_ERROR = new EclEmmaStatus(
+      5003, IStatus.ERROR, CoreMessages.StatusMERGE_SESSIONS_ERROR_message);
 
   /**
    * The execution data file can not be created.
@@ -103,12 +115,6 @@ public final class EclEmmaStatus {
    */
   public static final EclEmmaStatus EXPORT_ERROR = new EclEmmaStatus(5008,
       IStatus.ERROR, CoreMessages.StatusEXPORT_ERROR_message);
-
-  /**
-   * Error while importing external coverage session.
-   */
-  public static final EclEmmaStatus IMPORT_ERROR = new EclEmmaStatus(5009,
-      IStatus.ERROR, CoreMessages.StatusIMPORT_ERROR_message);
 
   /**
    * Error while starting the agent server.

--- a/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/CoreMessages.java
+++ b/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/CoreMessages.java
@@ -29,13 +29,14 @@ public class CoreMessages extends NLS {
   public static String MergingCoverageSessions_task;
 
   public static String StatusNO_LOCAL_AGENTJAR_ERROR_message;
+  public static String StatusSESSION_LOAD_ERROR_message;
   public static String StatusUNKOWN_LAUNCH_TYPE_ERROR_message;
+  public static String StatusMERGE_SESSIONS_ERROR_message;
   public static String StatusEXEC_FILE_CREATE_ERROR_message;
   public static String StatusEXEC_FILE_READ_ERROR_message;
   public static String StatusAGENT_CONNECT_ERROR_message;
   public static String StatusBUNDLE_ANALYSIS_ERROR_message;
   public static String StatusEXPORT_ERROR_message;
-  public static String StatusIMPORT_ERROR_message;
   public static String StatusAGENTSERVER_START_ERROR_message;
   public static String StatusAGENTSERVER_STOP_ERROR_message;
   public static String StatusEXECDATA_DUMP_ERROR_message;

--- a/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/JavaCoverageLoader.java
+++ b/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/JavaCoverageLoader.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.util.NLS;
 
+import com.mountainminds.eclemma.core.EclEmmaStatus;
 import com.mountainminds.eclemma.core.ICoverageSession;
 import com.mountainminds.eclemma.core.ISessionListener;
 import com.mountainminds.eclemma.core.ISessionManager;
@@ -80,7 +81,7 @@ public class JavaCoverageLoader {
       try {
         c = new SessionAnalyzer().processSession(session, monitor);
       } catch (CoreException e) {
-        return e.getStatus();
+        return EclEmmaStatus.SESSION_LOAD_ERROR.getStatus(e);
       }
       coverage = monitor.isCanceled() ? null : c;
       fireCoverageChanged();

--- a/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/coremessages.properties
+++ b/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/coremessages.properties
@@ -21,13 +21,14 @@ ImportingSession_task=Importing coverage session
 MergingCoverageSessions_task=Merging coverage sessions
 
 StatusNO_LOCAL_AGENTJAR_ERROR_message=Local agent jar can not be obtained (code {0}).
+StatusSESSION_LOAD_ERROR_message=Error while loading coverage session (code {0}).
 StatusUNKOWN_LAUNCH_TYPE_ERROR_message=Unknown launch type {1} (code {0}).
+StatusMERGE_SESSIONS_ERROR_message=Error while merging coverage sessions (code {0}).
 StatusEXEC_FILE_CREATE_ERROR_message=Execution data file can not be created (code {0}).
 StatusEXEC_FILE_READ_ERROR_message=Error while reading execution data file {1} (code {0}).
 StatusAGENT_CONNECT_ERROR_message=Error while connecting to JaCoCo agent at address {1} on port {2} (code {0}).
 StatusBUNDLE_ANALYSIS_ERROR_message=Error while analyzing package fragment root {1} at {2} (code {0}).
 StatusEXPORT_ERROR_message=Error while exporting coverage session (code {0}).
-StatusIMPORT_ERROR_message=Error while importing coverage session (code {0}).
 StatusAGENTSERVER_START_ERROR_message=Error while starting the agent server (code {0}).
 StatusAGENTSERVER_STOP_ERROR_message=Error while stopping the agent server (code {0}).
 StatusEXECDATA_DUMP_ERROR_message=Error while dumping coverage data (code {0}).

--- a/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/launching/AgentServer.java
+++ b/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/internal/core/launching/AgentServer.java
@@ -125,7 +125,7 @@ public class AgentServer extends Job {
     } catch (IOException e) {
       return EclEmmaStatus.EXECDATA_DUMP_ERROR.getStatus(e);
     } catch (CoreException e) {
-      return e.getStatus();
+      return EclEmmaStatus.EXECDATA_DUMP_ERROR.getStatus(e);
     }
   }
 

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/EclEmmaUIPlugin.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/EclEmmaUIPlugin.java
@@ -13,7 +13,6 @@ package com.mountainminds.eclemma.internal.ui;
 
 import java.net.URL;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -146,10 +145,6 @@ public class EclEmmaUIPlugin extends AbstractUIPlugin {
       message = "Internal Error"; //$NON-NLS-1$
     }
     instance.getLog().log(errorStatus(message, t));
-  }
-
-  public static void log(CoreException t) {
-    instance.getLog().log(t.getStatus());
   }
 
   public static ImageDescriptor getImageDescriptor(String key) {

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/handlers/DumpExecutionDataHandler.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/handlers/DumpExecutionDataHandler.java
@@ -35,6 +35,7 @@ import org.eclipse.ui.dialogs.ListDialog;
 import org.eclipse.ui.handlers.HandlerUtil;
 
 import com.mountainminds.eclemma.core.CoverageTools;
+import com.mountainminds.eclemma.core.EclEmmaStatus;
 import com.mountainminds.eclemma.core.launching.ICoverageLaunch;
 import com.mountainminds.eclemma.internal.ui.ContextHelp;
 import com.mountainminds.eclemma.internal.ui.EclEmmaUIPlugin;
@@ -122,7 +123,7 @@ public class DumpExecutionDataHandler extends AbstractHandler {
               .getBoolean(UIPreferences.PREF_RESET_ON_DUMP);
           launch.requestDump(reset);
         } catch (CoreException e) {
-          return e.getStatus();
+          return EclEmmaStatus.DUMP_REQUEST_ERROR.getStatus(e);
         }
         return Status.OK_STATUS;
       }

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/handlers/MergeSessionsHandler.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/handlers/MergeSessionsHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.handlers.HandlerUtil;
 
 import com.mountainminds.eclemma.core.CoverageTools;
+import com.mountainminds.eclemma.core.EclEmmaStatus;
 import com.mountainminds.eclemma.core.ICoverageSession;
 import com.mountainminds.eclemma.core.ISessionManager;
 import com.mountainminds.eclemma.internal.ui.UIMessages;
@@ -70,7 +71,7 @@ public class MergeSessionsHandler extends AbstractSessionManagerHandler {
         try {
           sm.mergeSessions(sessions, description, monitor);
         } catch (CoreException e) {
-          return e.getStatus();
+          return EclEmmaStatus.MERGE_SESSIONS_ERROR.getStatus(e);
         }
         return Status.OK_STATUS;
       }

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/wizards/SessionExportWizard.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/wizards/SessionExportWizard.java
@@ -13,7 +13,6 @@ package com.mountainminds.eclemma.internal.ui.wizards;
 
 import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -95,13 +94,8 @@ public class SessionExportWizard extends Wizard implements IExportWizard {
       final String title = UIMessages.ExportReportErrorDialog_title;
       String msg = UIMessages.ExportReportErrorDialog_message;
       msg = NLS.bind(msg, session.getDescription());
-      final IStatus status;
-      if (ex instanceof CoreException) {
-        status = ((CoreException) ex).getStatus();
-      } else {
-        status = EclEmmaUIPlugin.errorStatus(String.valueOf(ex.getMessage()),
-            ex);
-      }
+      final IStatus status = EclEmmaUIPlugin.errorStatus(
+          String.valueOf(ex.getMessage()), ex);
       ErrorDialog.openError(getShell(), title, msg, status);
       return false;
     }

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/wizards/SessionImportWizard.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/wizards/SessionImportWizard.java
@@ -13,7 +13,6 @@ package com.mountainminds.eclemma.internal.ui.wizards;
 
 import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -98,13 +97,8 @@ public class SessionImportWizard extends Wizard implements IImportWizard {
       EclEmmaUIPlugin.log(ex);
       final String title = UIMessages.ImportReportErrorDialog_title;
       final String msg = UIMessages.ImportReportErrorDialog_message;
-      final IStatus status;
-      if (ex instanceof CoreException) {
-        status = ((CoreException) ex).getStatus();
-      } else {
-        status = EclEmmaUIPlugin.errorStatus(String.valueOf(ex.getMessage()),
-            ex);
-      }
+      final IStatus status = EclEmmaUIPlugin.errorStatus(
+          String.valueOf(ex.getMessage()), ex);
       ErrorDialog.openError(getShell(), title, msg, status);
       return false;
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3365616/9309388/1faef110-44be-11e5-8ff5-147420379a95.png)

To me, this looks like it might not be an issue with EclEmma, but since I'm not seeing this error except when running coverage I thought I'd start here. I'm semi-familiar with what this error means in general in Java, which makes me wonder why I'm only seeing it when running coverage.

If anyone knows a tip for tracking it down, let me know!
