### PR TITLE
Fix compilation errors reported in Eclipse Mars

### DIFF
--- a/com.mountainminds.eclemma.core.test/src/com/mountainminds/eclemma/internal/core/SessionManagerTest.java
+++ b/com.mountainminds.eclemma.core.test/src/com/mountainminds/eclemma/internal/core/SessionManagerTest.java
@@ -499,18 +499,21 @@ public class SessionManagerTest {
       return 0;
     }
 
-    public List<?> getAttribute(String attributeName,
-        @SuppressWarnings("rawtypes") List defaultValue) throws CoreException {
+    @SuppressWarnings("rawtypes")
+    public List getAttribute(String attributeName, List defaultValue)
+        throws CoreException {
       return null;
     }
 
-    public Set<?> getAttribute(String attributeName,
-        @SuppressWarnings("rawtypes") Set defaultValue) throws CoreException {
+    @SuppressWarnings("rawtypes")
+    public Set getAttribute(String attributeName, Set defaultValue)
+        throws CoreException {
       return null;
     }
 
-    public Map<?, ?> getAttribute(String attributeName,
-        @SuppressWarnings("rawtypes") Map defaultValue) throws CoreException {
+    @SuppressWarnings("rawtypes")
+    public Map getAttribute(String attributeName, Map defaultValue)
+        throws CoreException {
       return null;
     }
 
@@ -519,7 +522,8 @@ public class SessionManagerTest {
       return null;
     }
 
-    public Map<?, ?> getAttributes() throws CoreException {
+    @SuppressWarnings("rawtypes")
+    public Map getAttributes() throws CoreException {
       return null;
     }
 
@@ -547,7 +551,8 @@ public class SessionManagerTest {
       return null;
     }
 
-    public Set<?> getModes() throws CoreException {
+    @SuppressWarnings("rawtypes")
+    public Set getModes() throws CoreException {
       return null;
     }
 

--- a/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/core/ScopeUtils.java
+++ b/com.mountainminds.eclemma.core/src/com/mountainminds/eclemma/core/ScopeUtils.java
@@ -107,8 +107,9 @@ public final class ScopeUtils {
   public static Set<IPackageFragmentRoot> getConfiguredScope(
       final ILaunchConfiguration configuration) throws CoreException {
     final Set<IPackageFragmentRoot> all = getOverallScope(configuration);
+    @SuppressWarnings("rawtypes")
     final List<?> selection = configuration.getAttribute(
-        ICoverageLaunchConfigurationConstants.ATTR_SCOPE_IDS, (List<?>) null);
+        ICoverageLaunchConfigurationConstants.ATTR_SCOPE_IDS, (List) null);
     if (selection == null) {
       final DefaultScopeFilter filter = new DefaultScopeFilter(
           EclEmmaCorePlugin.getInstance().getPreferences());


### PR DESCRIPTION
Prior to this change Eclipse 4.5.2 Mars (Build id: 20160218-0600) shows compilation errors in `com.mountainminds.eclemma.core`, `com.mountainminds.eclemma.core.test` and `com.mountainminds.eclemma.debug.ui.compatibility`.

Also

```
mvn clean verify \
    -Dimplicit-target \
    -Dplatform-repository-url=http://download.eclipse.org/releases/mars/
```

will stop at `com.mountainminds.eclemma.core` with inability to compile.

After this change the only remaining compilation error is in `com.mountainminds.eclemma.debug.ui.compatibility` and same Maven command will pass tests.

Result of opening of project in Eclipse 3.8 Juno is the same as before - only `com.mountainminds.eclemma.debug.ui.compatibility` contains compilation error - "cycle in the type hierarchy" what was done on purpose for compatibility with Eclipse < 3.8.
