### PR TITLE
Fix compilation errors reported in Eclipse Neon

### DIFF
--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/ScopeViewer.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/ScopeViewer.java
@@ -82,8 +82,8 @@ public class ScopeViewer implements ISelectionProvider {
     public int compare(Viewer viewer, Object e1, Object e2) {
       IPackageFragmentRoot root1 = (IPackageFragmentRoot) e1;
       IPackageFragmentRoot root2 = (IPackageFragmentRoot) e2;
-      @SuppressWarnings("unchecked")
-      final Comparator<Object> comparator = getComparator();
+      @SuppressWarnings("rawtypes")
+      final Comparator comparator = getComparator();
       int result = comparator.compare(root1.getJavaProject().getElementName(),
           root2.getJavaProject().getElementName());
       if (result != 0)

--- a/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/annotation/CoverageAnnotationModel.java
+++ b/com.mountainminds.eclemma.ui/src/com/mountainminds/eclemma/internal/ui/annotation/CoverageAnnotationModel.java
@@ -287,7 +287,7 @@ public final class CoverageAnnotationModel implements IAnnotationModel {
     throw new UnsupportedOperationException();
   }
 
-  public Iterator<?> getAnnotationIterator() {
+  public Iterator getAnnotationIterator() {
     return annotations.iterator();
   }
 


### PR DESCRIPTION
Prior to this change Eclipse 4.6.0 Neon (Build id: 20160613-1800) shows compilation errors in `com.mountainminds.eclemma.ui` and `com.mountainminds.eclemma.debug.ui.compatibility`.

After this change the only remaining compilation error is the same as with Eclipse 3.8 - "cycle in the type hierarchy" in `com.mountainminds.eclemma.debug.ui.compatibility` what was done on purpose for compatibility with Eclipse < 3.8.
